### PR TITLE
scores_percentage_fix + changes

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -78,6 +78,16 @@
         "score": 0,
         "totalQuestions": 5,
         "date": "2025-04-03T15:29:32.495Z"
+      },
+      {
+        "score": 0,
+        "totalQuestions": 5,
+        "date": "2025-04-11T17:24:28.300Z"
+      },
+      {
+        "score": 0,
+        "totalQuestions": 10,
+        "date": "2025-04-11T17:36:50.951Z"
       }
     ],
     "isAdmin": true,

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -305,6 +305,7 @@ textarea:focus {
 
 .options {
   display: grid;
+  grid-template-columns: 1fr 1fr;
   grid-gap: 1rem;
   margin-bottom: 2rem;
 }
@@ -649,4 +650,20 @@ input[type="radio"]:checked + .option-label {
     width: 100%;
     margin-bottom: 1rem;
   }
+}
+
+@keyframes blink {
+  0% {
+    background-color: red;
+  }
+  50% {
+    background-color: orange;
+  }
+  100% {
+    background-color: red;
+  }
+}
+
+.blinking {
+  animation: blink 1s infinite;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -511,7 +511,7 @@ input[type="radio"]:checked + .option-label {
   background-color: var(--light-gray);
 }
 
-.score-percentage {
+.percentage {
   display: inline-block;
   padding: 0.3rem 0.8rem;
   border-radius: var(--border-radius);

--- a/views/quiz_question.ejs
+++ b/views/quiz_question.ejs
@@ -45,9 +45,9 @@
           <% if (feedback.isCorrect) { %>
             <p class="correct-message">Correct! Great job!</p>
           <% } else if (feedback.isTimeUp) { %>
-            <p class="timeout-message">Time's up! The correct answer was: <%= feedback.correctAnswer %> (<%= question[feedback.correctAnswer] %>)</p>
+            <p class="timeout-message">Time's up! The correct answer was:  (<%= question[feedback.correctAnswer] %>)</p>
           <% } else { %>
-            <p class="incorrect-message">Incorrect. The correct answer was: <%= feedback.correctAnswer %> (<%= question[feedback.correctAnswer] %>)</p>
+            <p class="incorrect-message">Incorrect. The correct answer was:  (<%= question[feedback.correctAnswer] %>)</p>
           <% } %>
         </div>
       <% } %>
@@ -66,9 +66,11 @@ document.addEventListener('DOMContentLoaded', function() {
   const answerForm = document.getElementById('answerForm');
   const hasOptions = document.querySelectorAll('input[name="answer"]');
   const submitBtn = document.querySelector('.submit-btn');
+  const timerContainer = document.querySelector('.timer-container');  // Select the timer container
   
   // Auto-advance when feedback is displayed.
   if (feedbackExists) {
+    timerContainer.style.display = 'none';
     const nextButton = document.createElement('a');
     nextButton.textContent = 'Continue to Next Question';
     nextButton.href = '/quiz/question';
@@ -83,12 +85,17 @@ document.addEventListener('DOMContentLoaded', function() {
     }, 3000);
     return;
   }
-  
+
   // Timer: update every second and auto-submit when time runs out.
   const timerInterval = setInterval(function() {
     timeLeft--;
     timerElement.textContent = timeLeft;
     
+    // Add blinking effect if timeLeft is 5 seconds or less
+    if (timeLeft <= 5) {
+      timerContainer.classList.add('blinking');
+    }
+
     if (timeLeft <= 0) {
       clearInterval(timerInterval);
       timeUpField.value = 'true';

--- a/views/score_history.ejs
+++ b/views/score_history.ejs
@@ -20,7 +20,7 @@
                             <td><%= index + 1 %></td>
                             <td><%= score.score %>/<%= score.totalQuestions %></td>
                             <td>
-                                <div class="score-percentage <%= Math.round((score.score / score.totalQuestions) * 100) >= 70 ? 'high' : Math.round((score.score / score.totalQuestions) * 100) >= 40 ? 'medium' : 'low' %>">
+                                <div class="percentage <%= Math.round((score.score / score.totalQuestions) * 100) >= 70 ? 'high' : Math.round((score.score / score.totalQuestions) * 100) >= 40 ? 'medium' : 'low' %>">
                                     <%= Math.round((score.score / score.totalQuestions) * 100) %>%
                                 </div>
                             </td>


### PR DESCRIPTION
Fix for percentage displaying as white on table of past scores, causing it to not be visible.

Changes in quiz_question:

- When timer <= 5 seconds change timer background to blink between red and orange.
- When the question is submitted(either from timer running out or user submission), get rid of timer box on the feedback page.
- Got rid of letter choice on the feedback page answer feedback.
- Changed the layout by adding a column.