### PR TITLE
Avatar menu close, Link fix, Results Page Dropdown Clarification

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -233,6 +233,7 @@ details[open] .avatar::after {
 
 /* Avatar image style */
 .avatar-img {
+  user-select: none;
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -242,6 +243,7 @@ details[open] .avatar::after {
 
 /* Dropdown menu style */
 .dropdown-menu {
+  user-select: none;
   display: none;
   position: absolute;
   top: 100%;
@@ -281,7 +283,7 @@ details[open] .avatar::after {
   transition: background-color 0.3s ease;
 }
 
-.dropdown-menu li:hover {
+.dropdown-menu li a:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
@@ -307,10 +309,6 @@ details.dropdown summary {
   cursor: pointer;
 }
 
-details.dropdown summary::-webkit-details-marker {
-  display: none;
-}
-
 /* Footer */
 footer {
   background-color: rgba(0, 0, 0, 0.5); /* semi-transparent to show bg */
@@ -325,7 +323,6 @@ footer {
   z-index: 1000;
   image-rendering: pixelated;
 }
-
 
 /* Forms */
 .form-group {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -112,6 +112,7 @@ a:hover {
 
 /* Header & Navigation */
 header {
+  user-select: none;
   background-color: rgba(0, 0, 0, 0.5);
   color: white;
   font-family: 'Press Start 2P', cursive;
@@ -233,7 +234,6 @@ details[open] .avatar::after {
 
 /* Avatar image style */
 .avatar-img {
-  user-select: none;
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -243,7 +243,6 @@ details[open] .avatar::after {
 
 /* Dropdown menu style */
 .dropdown-menu {
-  user-select: none;
   display: none;
   position: absolute;
   top: 100%;

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -55,5 +55,18 @@
 			</nav>
 		</div>
 	</header>
+	<script>
+	const dropdown = document.querySelector('.dropdown');
+	const dropdownContainer = document.querySelector('.dropdown-container');
+
+	function closeDropdown(e) {
+		if (!dropdownContainer.contains(e.target)) {
+		dropdown.removeAttribute('open');
+		}
+	}
+
+	document.addEventListener('click', closeDropdown);
+	</script>
+	</body>
 
 	<main class="container">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -75,7 +75,7 @@
 
     <div class="profile-actions">
         <a href="/quiz/setup" class="btn btn-primary">Play New Quiz</a>
-        <a href="/leaderboard" class="btn btn-info">View Leaderboard</a>
+        <a href="/quiz/leaderboard" class="btn btn-info">View Leaderboard</a>
     </div>
 </div>
 

--- a/views/quiz_results.ejs
+++ b/views/quiz_results.ejs
@@ -62,6 +62,8 @@
                             ❌ Incorrect
                         <% } %>
                     </div>
+                    <h6>Click To Expand:</h6>
+                    <br>
                 </summary>
                 <div class="review-result-body">
                     <% if (answer.selectedAnswer !== '') { %>


### PR DESCRIPTION
Changes:
-Avatar Menu closes when clicking outside of it
-Disable user from double clicking and highlighting of anything on the header
-Link to leaderboard in profile fixed
-Clarification of dropdown in quiz results page